### PR TITLE
Fixed typo on the Advanced Mathematics Trials, Pymble 2022-2023 section.

### DIFF
--- a/yr12/Maths/trialpapers_advanced.html
+++ b/yr12/Maths/trialpapers_advanced.html
@@ -574,8 +574,8 @@
 <a href="#v" onClick="pdf(this, 5328)">Pymble 2014 w. sol</a><br />
 <a href="#v" onClick="pdf(this, 5328)">Pymble 2015 w. sol</a><br />
 <a href="#v" onClick="pdf(this, 5328)">Pymble 2016 w. sol</a><br />
-<a href="#v" onClick="pdf(this, 5328)">Pymble 2017</a><br /><br />
-<a href="#v" onClick="pdf(this, 5328)">Pymble 2022 w. sol</a>
+<a href="#v" onClick="pdf(this, 5328)">Pymble 2017</a><br />
+<a href="#v" onClick="pdf(this, 5328)">Pymble 2022 w. sol</a><br />
 <a href="#v" onClick="pdf(this, 5328)">Pymble 2023 w. sol</a>
 </span></td></tr>
 <tr><td>Riverview<br />


### PR DESCRIPTION
</ br> had been repeated twice in a row rather than consecutively between each one.